### PR TITLE
upgrade to testing v3, use test suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@alcalzone/release-script": "^3.5.8",
     "@alcalzone/release-script-plugin-iobroker": "^3.5.8",
     "@alcalzone/release-script-plugin-license": "^3.5.8",
-    "@iobroker/testing": "^3.0.1",
+    "@iobroker/testing": "^3.0.2",
     "chai": "^4.3.6",
     "eslint-plugin-eqeqeq-fix": "^1.0.3",
     "eslint-plugin-only-warn": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -21,25 +21,25 @@
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.0",
     "@iobroker/socket-classes": "^0.1.5",
-    "express": "^4.18.1",
+    "axios": "^0.27.2",
     "body-parser": "^1.20.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.1",
     "swagger-node-runner-fork": "^0.8.0",
     "swagger-ui-express": "^4.3.0",
-    "yamljs": "^0.3.0",
-    "axios": "^0.27.2",
-    "cors": "^2.8.5"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@alcalzone/release-script": "^3.5.8",
     "@alcalzone/release-script-plugin-iobroker": "^3.5.8",
     "@alcalzone/release-script-plugin-license": "^3.5.8",
+    "@iobroker/testing": "^3.0.1",
+    "chai": "^4.3.6",
     "eslint-plugin-eqeqeq-fix": "^1.0.3",
     "eslint-plugin-only-warn": "^1.0.3",
     "eslint-plugin-react": "^7.29.4",
-    "mocha": "^9.2.2",
-    "chai": "^4.3.6",
-    "@iobroker/testing": "^2.6.0",
-    "gulp": "^4.0.2"
+    "gulp": "^4.0.2",
+    "mocha": "^9.2.2"
   },
   "bugs": {
     "url": "https://github.com/ioBroker/ioBroker.rest-api/issues"

--- a/test/testApi.js
+++ b/test/testApi.js
@@ -60,11 +60,13 @@ tests.integration(path.join(__dirname, '..'), {
     loglevel: 'info',
 
     defineAdditionalTests({ suite }) {
-        suite('Test REST API', (harness) => {
+        suite('Test REST API', (getHarness) => {
+            let harness;
             before(async function () {
                 // The adapter start can take a bit
                 this.timeout(TESTS_TIMEOUT);
 
+                harness = getHarness();
                 await setupTests(harness);
 
                 await harness.changeAdapterConfig(harness.adapterName, {
@@ -82,7 +84,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 const response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive`);
                 const obj = response.data;
-                console.log(`get/system.adapter.${harness.adapterName}.0.alive => ${JSON.stringify(response.data)}`);
+                // console.log(`get/system.adapter.${harness.adapterName}.0.alive => ${JSON.stringify(response.data)}`);
                 //
                 // {
                 //   "val": true,
@@ -105,7 +107,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 const response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive?withInfo=true`);
                 const obj = response.data;
-                console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive?withInfo=true => ${JSON.stringify(response.data)}`);
+                // console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive?withInfo=true => ${JSON.stringify(response.data)}`);
                 //
                 // {
                 //   "val": true,
@@ -151,7 +153,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1?value=bla`);
                 const obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-string1?value=bla => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-string1?value=bla => ' + JSON.stringify(response.data));
                 //
                 // {
                 //   "id": "javascript.0.test-string1",
@@ -166,7 +168,7 @@ tests.integration(path.join(__dirname, '..'), {
                     responseEncoding: 'binary'
                 });
                 let body = response.data.toString('utf8');
-                console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + body);
+                // console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + body);
                 expect(body).equal('"bla"');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1/plain?extraPlain=true`, {
@@ -174,11 +176,11 @@ tests.integration(path.join(__dirname, '..'), {
                     responseEncoding: 'binary'
                 });
                 body = response.data.toString('utf8');
-                console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + body);
+                // console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + body);
                 expect(body).equal('bla');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1`);
-                console.log('get/javascript.0.test-string1 => ' + JSON.stringify(response.data));
+                // console.log('get/javascript.0.test-string1 => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal('bla');
             }).timeout(TESTS_TIMEOUT)
 
@@ -190,7 +192,7 @@ tests.integration(path.join(__dirname, '..'), {
                     responseEncoding: 'binary'
                 })
                 const body = response.data.toString('utf8');
-                console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive/plain => ${body} type is "${typeof body}"`);
+                // console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive/plain => ${body} type is "${typeof body}"`);
                 expect(body).equal('true');
             }).timeout(TESTS_TIMEOUT)
 
@@ -201,7 +203,7 @@ tests.integration(path.join(__dirname, '..'), {
                     val: '60',
                     ack: true
                 });
-                console.log('[PATCH] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
+                // console.log('[PATCH] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
                 const obj = response.data
                 expect(obj).to.be.ok;
                 expect(obj.val).to.equal('60');
@@ -211,7 +213,7 @@ tests.integration(path.join(__dirname, '..'), {
                 await new Promise(resolve => setTimeout(() => resolve(), 2000));
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1`);
-                console.log('[GET] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal('60');
             }).timeout(TESTS_TIMEOUT)
 
@@ -220,17 +222,17 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1?value=bla%26fasel%2efoo%3Dhummer+hey`);
                 const obj = response.data
-                console.log('[GET] /v1/state/javascript.0.test-string1?value=bla%26fasel%2efoo%3Dhummer+hey => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/state/javascript.0.test-string1?value=bla%26fasel%2efoo%3Dhummer+hey => ' + JSON.stringify(obj));
                 expect(obj).to.be.ok;
                 expect(obj.val).equal('bla&fasel.foo=hummer hey');
                 expect(obj.id).to.equal('javascript.0.test-string1');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1/plain`);
-                console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + response.data);
+                // console.log('[GET] /v1/state/javascript.0.test-string1/plain => ' + response.data);
                 expect(response.data).equal('bla&fasel.foo=hummer hey');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-string1`);
-                console.log('[GET] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-string1 => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal('bla&fasel.foo=hummer hey');
             }).timeout(TESTS_TIMEOUT)
 
@@ -239,7 +241,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-boolean?value=true`);
                 const obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-boolean?value=true => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-boolean?value=true => ' + JSON.stringify(response.data));
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.true;
                 expect(obj.id).to.equal('javascript.0.test-boolean');
@@ -248,7 +250,7 @@ tests.integration(path.join(__dirname, '..'), {
                     responseEncoding: 'binary'
                 });
                 const body = response.data.toString('utf8');
-                console.log(`[GET] http://127.0.0.1:${PORT}/javascript.0.test-boolean => ` + body);
+                // console.log(`[GET] http://127.0.0.1:${PORT}/javascript.0.test-boolean => ` + body);
                 expect(body).equal('true');
             }).timeout(TESTS_TIMEOUT)
 
@@ -257,13 +259,13 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-boolean/toggle`);
                 const obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-boolean/toggle] => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/state/javascript.0.test-boolean/toggle] => ' + JSON.stringify(obj));
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.false;
                 expect(obj.id).to.equal('javascript.0.test-boolean');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-boolean`);
-                console.log('[GET] /v1/state/javascript.0.test-boolean => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-boolean => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal(false);
             }).timeout(TESTS_TIMEOUT)
 
@@ -272,13 +274,13 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-boolean/toggle`);
                 const obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-boolean/toggle] => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/state/javascript.0.test-boolean/toggle] => ' + JSON.stringify(obj));
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.true;
                 expect(obj.id).to.equal('javascript.0.test-boolean');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-boolean`);
-                console.log('[GET] /v1/state/javascript.0.test-boolean => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-boolean => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal(true);
             }).timeout(TESTS_TIMEOUT)
 
@@ -287,27 +289,27 @@ tests.integration(path.join(__dirname, '..'), {
 
                 let response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-number/toggle`);
                 let obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-number/toggle] => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/state/javascript.0.test-number/toggle] => ' + JSON.stringify(obj));
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.equal(100);
                 expect(obj.id).to.equal('javascript.0.test-number');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-number`);
-                console.log('[GET] /v1/state/javascript.0.test-number => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-number => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal(100);
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-number?value=49`);
-                console.log('[GET] /v1/state/javascript.0.test-number?value=49 => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-number?value=49 => ' + JSON.stringify(response.data));
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-number/toggle`);
                 obj = response.data;
-                console.log('[GET] /v1/state/javascript.0.test-number/toggle => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-number/toggle => ' + JSON.stringify(response.data));
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.equal(51);
                 expect(obj.id).to.equal('javascript.0.test-number');
 
                 response = await axios.get(`http://127.0.0.1:${PORT}/v1/state/javascript.0.test-number`);
-                console.log('[GET] /v1/state/javascript.0.test-number => ' + JSON.stringify(response.data));
+                // console.log('[GET] /v1/state/javascript.0.test-number => ' + JSON.stringify(response.data));
                 expect(response.data.val).equal(51);
             }).timeout(TESTS_TIMEOUT)
 
@@ -316,7 +318,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 const response = await axios.get(`http://127.0.0.1:${PORT}/v1/objects?filter=system.adapter.*`);
                 const obj = response.data
-                console.log('[GET] /v1/objects?filter=system.adapter.* => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/objects?filter=system.adapter.* => ' + JSON.stringify(obj));
                 expect(obj[`system.adapter.${harness.adapterName}.0.alive`]._id).to.be.ok;
             }).timeout(TESTS_TIMEOUT)
 
@@ -325,7 +327,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 const response = await axios.get(`http://127.0.0.1:${PORT}/v1/objects?filter=system.adapter.*&type=instance`);
                 const obj = response.data
-                console.log('[GET] /v1/objects?filter=system.adapter.*&type=instance => ' + JSON.stringify(obj));
+                // console.log('[GET] /v1/objects?filter=system.adapter.*&type=instance => ' + JSON.stringify(obj));
                 expect(obj[`system.adapter.${harness.adapterName}.0`]._id).to.be.ok;
                 expect(obj[`system.adapter.${harness.adapterName}.0.alive`]).to.be.not.ok;
             }).timeout(TESTS_TIMEOUT)
@@ -335,7 +337,7 @@ tests.integration(path.join(__dirname, '..'), {
 
                 const response = await axios.get(`http://127.0.0.1:${PORT}/v1/states?filter=system.adapter.*`);
                 const states = response.data
-                console.log('[GET] /v1/states?filter=system.adapter.* => ' + JSON.stringify(states));
+                // console.log('[GET] /v1/states?filter=system.adapter.* => ' + JSON.stringify(states));
                 expect(states[`system.adapter.${harness.adapterName}.0`]).to.be.not.ok;
                 expect(states[`system.adapter.${harness.adapterName}.0.uptime`].val).to.be.least(0);
             }).timeout(TESTS_TIMEOUT)

--- a/test/testApiAsUser.js
+++ b/test/testApiAsUser.js
@@ -122,10 +122,12 @@ tests.integration(path.join(__dirname, '..'), {
     loglevel: 'info',
 
     defineAdditionalTests({ suite }) {
-        suite('Test RESTful API as User', (harness) => {
+        suite('Test RESTful API as User', (getHarness) => {
+            let harness;
             before(async function () {
                 // The adapter start can take a bit
                 this.timeout(TESTS_TIMEOUT);
+                harness = getHarness();
                 await setupTests(harness);
             });
 

--- a/test/testSsl.js
+++ b/test/testSsl.js
@@ -1,74 +1,55 @@
 const path = require('path');
-const {tests} = require('@iobroker/testing');
+const { tests } = require('@iobroker/testing');
 const axios = require('axios');
-const {expect} = require('chai');
-const adapterName = require('../package.json').name.split('.').pop();
+const { expect } = require('chai');
 
 const PORT = 18186;
 const TESTS_TIMEOUT = 10000;
 
 process.env.NO_PROXY = '127.0.0.1';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-async function waitForState(harness, id, value) {
-    const started = await harness.states.getState(id);
-    if (!started.val) {
-        await new Promise(resolve => harness.on('stateChange', (id, state) => {
-            if (id.endsWith('info.connection') && state.val === value) {
-                resolve();
-            }
-        }));
-    }
-}
-
-async function setupTests(harness) {
-    // Enable the adapter and set its loglevel to debug
-    await harness.changeAdapterConfig(adapterName, {
-        common: {
-            enabled: true,
-            loglevel: 'debug',
-        },
-        native: {
-            bind: '127.0.0.1',
-            port: PORT,
-            auth: true,
-            secure: true,
-            certPublic: 'defaultPublic',
-            certPrivate: 'defaultPrivate',
-        }
-    });
-
-    // Start the adapter and wait until it has started
-    await harness.startAdapterAndWait();
-
-    await waitForState(harness, adapterName + '.0.info.connection', true);
-}
 
 // Run tests
 tests.integration(path.join(__dirname, '..'), {
     allowedExitCodes: [11],
     loglevel: 'info',
 
-    defineAdditionalTests(getHarness) {
-        describe('Test REST API SSL', () => {
-            it('Test REST API SSL: get - must return value', async () => {
-                const harness = getHarness();
-                await setupTests(harness);
+    defineAdditionalTests({ suite }) {
+        suite('Test REST API SSL', (harness) => {
+            before(async function () {
+                // The adapter start can take a bit
+                this.timeout(TESTS_TIMEOUT);
 
-                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${adapterName}.0.alive?user=admin&pass=iobroker`)
+                await harness.changeAdapterConfig(harness.adapterName, {
+                    native: {
+                        bind: '127.0.0.1',
+                        port: PORT,
+                        auth: true,
+                        secure: true,
+                        certPublic: 'defaultPublic',
+                        certPrivate: 'defaultPrivate',
+                    }
+                });
+                // Start the adapter and wait until it has started
+                await harness.startAdapterAndWait(true);
+            });
+
+            it('Test REST API SSL: get - must return value', async () => {
+                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive?user=admin&pass=iobroker`)
                 const obj = response.data;
-                console.log(`[GET] /v1/state/system.adapter.${adapterName}.0.alive?user=admin&pass=iobroker => ${JSON.stringify(obj)}`);
+                console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive?user=admin&pass=iobroker => ${JSON.stringify(obj)}`);
                 //{
                 //    "val" : true,
                 //    "ack" : true,
                 //    "ts" : 1455009717,
                 //    "q" : 0,
-                //    "from" : "system.adapter.${adapterName}.0",
+                //    "from" : "system.adapter.${harness.adapterName}.0",
                 //    "lc" : 1455009717,
                 //    "expire" : 30000,
-                //    "_id" : "system.adapter.${adapterName}.0.alive",
+                //    "_id" : "system.adapter.${harness.adapterName}.0.alive",
                 //    "type" : "state",
                 //    "common" : {
-                //      "name" : "${adapterName}.0.alive",
+                //      "name" : "${harness.adapterName}.0.alive",
                 //        "type" : "boolean",
                 //        "role" : "indicator.state"
                 //       },
@@ -80,61 +61,49 @@ tests.integration(path.join(__dirname, '..'), {
                 expect(obj.val).to.be.true;
                 expect(obj.ack).to.be.true;
                 expect(obj.ts).to.be.ok;
-                expect(obj.from).to.equal(`system.adapter.${adapterName}.0`);
+                expect(obj.from).to.equal(`system.adapter.${harness.adapterName}.0`);
             })
                 .timeout(TESTS_TIMEOUT);
 
             it('Test REST API SSL: get - must return value with auth in header', async () => {
-                const harness = getHarness();
-                await setupTests(harness);
-
-                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${adapterName}.0.alive`, {
+                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive`, {
                     headers: {
                         'Authorization': 'Basic ' + Buffer.from('admin:iobroker').toString('base64')
                     }
                 });
                 const obj = response.data;
-                console.log(`[GET/Authorization] /v1/state/system.adapter.${adapterName}.0.alive => ${JSON.stringify(obj)}`);
+                console.log(`[GET/Authorization] /v1/state/system.adapter.${harness.adapterName}.0.alive => ${JSON.stringify(obj)}`);
                 expect(response.status).to.be.equal(200);
                 expect(obj).to.be.ok;
                 expect(obj.val).to.be.true;
                 expect(obj.ack).to.be.true;
                 expect(obj.ts).to.be.ok;
-                expect(obj.from).to.equal(`system.adapter.${adapterName}.0`);
+                expect(obj.from).to.equal(`system.adapter.${harness.adapterName}.0`);
             })
                 .timeout(TESTS_TIMEOUT);
 
             it('Test REST API SSL: get with no credentials', async () => {
-                const harness = getHarness();
-                await setupTests(harness);
-
-                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${adapterName}.0.alive`, {validateStatus: () => true})
-                console.log(`[GET] /v1/state/system.adapter.${adapterName}.0.alive => ${JSON.stringify(response.data)}`);
+                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive`, { validateStatus: () => true })
+                console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive => ${JSON.stringify(response.data)}`);
                 expect(response.status).to.be.equal(401);
             })
                 .timeout(TESTS_TIMEOUT);
 
             it('Test REST API SSL: get with wrong credentials', async () => {
-                const harness = getHarness();
-                await setupTests(harness);
-
-                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${adapterName}.0.alive?user=admin&pass=io`, {validateStatus: () => true})
-                console.log(`[GET] /v1/state/system.adapter.${adapterName}.0.alive?user=admin&pass=io => ${JSON.stringify(response.data)}`);
+                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive?user=admin&pass=io`, { validateStatus: () => true })
+                console.log(`[GET] /v1/state/system.adapter.${harness.adapterName}.0.alive?user=admin&pass=io => ${JSON.stringify(response.data)}`);
                 expect(response.status).to.be.equal(401);
             })
                 .timeout(TESTS_TIMEOUT);
 
             it('Test REST API SSL: get - get with wrong credentials in header', async () => {
-                const harness = getHarness();
-                await setupTests(harness);
-
-                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${adapterName}.0.alive`, {
+                const response = await axios.get(`https://127.0.0.1:${PORT}/v1/state/system.adapter.${harness.adapterName}.0.alive`, {
                     headers: {
                         'Authorization': 'Basic ' + Buffer.from('admin:io').toString('base64')
                     },
                     validateStatus: () => true
                 })
-                console.log(`[GET/Authorization] /v1/state/system.adapter.${adapterName}.0.alive => ${JSON.stringify(response.data)}`);
+                console.log(`[GET/Authorization] /v1/state/system.adapter.${harness.adapterName}.0.alive => ${JSON.stringify(response.data)}`);
                 expect(response.status).to.be.equal(401);
             })
                 .timeout(TESTS_TIMEOUT);

--- a/test/testSsl.js
+++ b/test/testSsl.js
@@ -15,10 +15,13 @@ tests.integration(path.join(__dirname, '..'), {
     loglevel: 'info',
 
     defineAdditionalTests({ suite }) {
-        suite('Test REST API SSL', (harness) => {
+        suite('Test REST API SSL', (getHarness) => {
+            let harness;
             before(async function () {
                 // The adapter start can take a bit
                 this.timeout(TESTS_TIMEOUT);
+
+                harness = getHarness();
 
                 await harness.changeAdapterConfig(harness.adapterName, {
                     native: {


### PR DESCRIPTION
This PR updates the testApi.js and testSsl.js to use the new test suite feature introduced in testing v3. During each suite, the adapter is only started once instead of once per test.