### PR TITLE
Fix webextension url at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This adapter supports a subscribing on data changes via long polling.
 Example for browser could be found here: [demoNodeClient.js](examples/demoBrowserClient.html)  
 
 ## Web extension
-This adapter can run as a web extension. In this case, the path is available under `http://ipaddress:8082/rest`
+This adapter can run as a web extension. In this case, the path is available under `http://ipaddress:8082/rest-api/`
 
 ## Notice
 - `POST` is always for creating a resource (does not matter if it was duplicated)


### PR DESCRIPTION
Looks like documentation stated a wrong url (rest instead of rest-api.

PLEASE VERIFY THAT REALLY /rest-api/ is CORRECT and if this is the case merge the PR.

fixes https://github.com/ioBroker/ioBroker.rest-api/issues/180

@Apollon77 
@GermanBluefox 